### PR TITLE
Allow local install

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'maven'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.8.4'
     id 'com.github.hierynomus.license' version '0.14.0'
@@ -7,7 +8,8 @@ plugins {
 
 allprojects {
     repositories {
-	jcenter()
+        jcenter()
+        mavenCentral()
     }
 }
 
@@ -19,6 +21,7 @@ subprojects {
 
 configure(subprojects.findAll {it.name != 'docs' && it.name != 'examples' && it.name != 'benchmarks'} ) {
     apply plugin: 'maven-publish'
+    apply plugin: 'maven'
     apply plugin: 'com.jfrog.bintray'
 
     publishing {


### PR DESCRIPTION
This change is to allow installing of jars into local maven repository. 

Doing:

`./gradlew install`

Will build and install into `.m2` 

I could not find a way to achieve the local installation with the current setup hence the modification.

I am not a gradle expert so I can't tell if this is the best approach to achieve this. So a review is appreciated.

