### PR TITLE
Minor changes to the doc to avoid ambiguity in the set up procedure

### DIFF
--- a/docs/progman.tex
+++ b/docs/progman.tex
@@ -398,7 +398,7 @@ properties of Ibis and their usage.
 %-- add ipl.jar to classpath, rewrite using iplc, example ant build file.
 
 Applications that use Ibis can be compiled as any normal Java
-application. The file \texttt{ipl-2.3.jar} needs to be added to the
+application. The file \texttt{ipl-[version-number].jar} needs to be added to the
 classpath when compiling (and running) an Ibis application. For the
 serialization of Ibis to function correctly, one additional step is
 required after compiling: the code for writing and reading objects must

--- a/docs/usersguide.tex
+++ b/docs/usersguide.tex
@@ -88,8 +88,9 @@ directory, on the class path, and at a location specified with the
 
 An application interfaces to Ibis using the \emph{Ibis Portability Layer} (IPL).
 The code for this package is provided in a single jar file:
-ipl.jar, appended with the version of ibis, for instance \texttt{ipl-2.3.jar}.
-It lives in the \emph{lib} directory of the Ibis distribution.
+ipl.jar, appended with the version of ibis, for instance \texttt{ipl-[version-number].jar}.
+It lives in the \emph{lib} directory of the Ibis distribution. Note that the \emph{lib}
+is generated after building the project by running \texttt{./gradelw build}.
 This jar file needs to be added to the class path of the application.
 
 \subsection{Provide the Ibis implementations}
@@ -254,7 +255,7 @@ the application without ipl-run, the following command can be used:
 \begin{verbatim}
 $ java \
     -cp \
-    $IPL_HOME/lib/ipl-2.3.jar:$IPL_HOME/examples/lib/ipl-examples.jar \
+    $IPL_HOME/lib/ipl-[version-number].jar:$IPL_HOME/examples/lib/ipl-examples.jar \
     -Dibis.implementation.path=$IPL_HOME/lib \
     -Dibis.server.address=localhost \
     -Dibis.pool.name=test \
@@ -324,7 +325,7 @@ This should just be a single line.
 {\small
 \begin{verbatim}
 C:\DOCUME~1\Temp> java
-    -cp "%IPL_HOME%"\lib\ipl-2.3.jar;"%IPL_HOME%"\examples\lib\ipl-examples.jar
+    -cp "%IPL_HOME%"\lib\ipl-[version-number].jar;"%IPL_HOME%"\examples\lib\ipl-examples.jar
     -Dibis.implementation.path="%IPL_HOME%"\lib
     -Dlog4j.configuration=file:"%IPL_HOME%"\log4j.properties
     -Dibis.server.address=localhost -Dibis.pool.name=test


### PR DESCRIPTION
The version number used in the guide is 2.3, the current version is 2.3.3. Changed hardcoding the version to using a placeholder.

Also mention that the project needs to be built in other to generate the `./lib` directory.